### PR TITLE
Add bun create template for CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # create-bun-cli-tool
+
+This repository contains a `bun create` template for bootstrapping a Bun
+native CLI tool.
+
+The template scaffolds a TypeScript project configured to build a single
+cross&#x2011;platform executable using `bun build --compile`. It includes
+preinstalled support for [commander](https://github.com/tj/commander.js/) and
+[ora](https://github.com/sindresorhus/ora) for building rich command line
+interfaces.
+
+## Usage
+
+```bash
+bun create ./create-bun-cli-tool <project-name>
+cd <project-name>
+bun install
+bun run build
+```
+
+After running `bun run build` the compiled executable is available in the
+`bin/` directory and can be published to npm as your CLI tool entry point.
+

--- a/create.ts
+++ b/create.ts
@@ -1,0 +1,24 @@
+import { cpSync, readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const args = Bun.argv.slice(2);
+const projectName = args[0] || "bun-cli";
+
+if (existsSync(projectName)) {
+  console.error(`${projectName} already exists`);
+  process.exit(1);
+}
+
+const templateDir = new URL("./template", import.meta.url).pathname;
+cpSync(templateDir, projectName, { recursive: true });
+
+const pkgPath = join(projectName, "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+
+pkg.name = projectName;
+pkg.bin = { [projectName]: `bin/${projectName}` };
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+console.log(`Created ${projectName}`);
+console.log(`Run:\n  cd ${projectName}\n  bun install\n  bun run build`);
+

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,12 @@
+# Bun CLI Tool
+
+This template creates a Bun based CLI application built with TypeScript.
+
+## Development
+
+```bash
+bun install
+bun run build
+```
+
+The executable will be placed in the `bin/` directory.

--- a/template/bunfig.toml
+++ b/template/bunfig.toml
@@ -1,0 +1,2 @@
+[bundle]
+target = "bun"

--- a/template/package.json
+++ b/template/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "bun-cli-template",
+  "version": "0.0.0",
+  "description": "Bun CLI tool template",
+  "type": "module",
+  "main": "bin/cli",
+  "bin": {
+    "cli": "bin/cli"
+  },
+  "scripts": {
+    "build": "bun run scripts/build.ts"
+  },
+  "dependencies": {
+    "commander": "^11.0.0",
+    "ora": "^6.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/template/scripts/build.ts
+++ b/template/scripts/build.ts
@@ -1,0 +1,17 @@
+import { readFile, mkdir } from "fs/promises";
+
+const pkg = JSON.parse(await readFile("package.json", "utf8"));
+const name = pkg.name || "cli";
+
+await mkdir("bin", { recursive: true });
+
+const proc = Bun.spawnSync({
+  cmd: ["bun", "build", "src/index.ts", "--compile", "--outfile", `bin/${name}`],
+});
+
+if (proc.exitCode !== 0) {
+  console.error(proc.stderr.toString());
+  process.exit(proc.exitCode);
+}
+
+console.log(`Built bin/${name}`);

--- a/template/src/index.ts
+++ b/template/src/index.ts
@@ -1,0 +1,20 @@
+import { Command } from "commander";
+import ora from "ora";
+
+const program = new Command();
+program
+  .name("mycli")
+  .description("Example bun CLI tool")
+  .version("0.1.0");
+
+program
+  .command("hello")
+  .description("Print hello")
+  .action(() => {
+    const spinner = ora("Processing...").start();
+    setTimeout(() => {
+      spinner.succeed("Hello from bun CLI!");
+    }, 500);
+  });
+
+program.parse(process.argv);

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add README instructions and notes on the template
- scaffold template project in `template/`
- implement `create.ts` to copy the template and customize package.json
- include example CLI setup using commander and ora

## Testing
- `bun run create.ts new-cli`
- `cd new-cli && bun install`
- `bun run scripts/build.ts`

------
https://chatgpt.com/codex/tasks/task_e_687171cbbb048332a598797e00b4ff13